### PR TITLE
Fixes for fonts

### DIFF
--- a/packages/gatsby-theme-iterative/src/components/Page/base.css
+++ b/packages/gatsby-theme-iterative/src/components/Page/base.css
@@ -16,8 +16,6 @@
   --color-purple-hover: #745cb7;
   --color-orange: #e37046;
   --color-orange-bright: #f46837;
-  --font-base: "Tahoma", "Arial", sans-serif;
-  --font-mono: "Consolas", "Liberation Mono", "Menlo", "Courier", monospace;
   --layout-width: 1005px;
   --layout-width-wide: 1200px;
   --layout-header-height: 72px;
@@ -35,7 +33,7 @@ html {
 }
 
 body {
-  font-family: var(--font-brandon);
+  font-family: var(--font-base);
   font-weight: 400;
   line-height: 1.5;
   color: var(--color-black);

--- a/packages/gatsby-theme-iterative/src/components/Page/fonts/fonts.css
+++ b/packages/gatsby-theme-iterative/src/components/Page/fonts/fonts.css
@@ -2,3 +2,8 @@
 * {
   text-size-adjust: none;
 }
+
+:root {
+  --font-base: "Tahoma", "Arial", sans-serif;
+  --font-mono: "Consolas", "Liberation Mono", "Menlo", "Courier", monospace;
+}


### PR DESCRIPTION
Makes fonts more feasible to override by shadowing `src/@gatsby-theme-iterative/components/Page/fonts/fonts.css`

Used in iterative/mlem.ai#45