### PR TITLE
Make required type declarations exportable from package

### DIFF
--- a/packages/gatsby-theme-iterative/package.json
+++ b/packages/gatsby-theme-iterative/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "",
   "main": "index.js",
+  "types": "src/typings.d.ts",
   "author": "Roger Parent (@rogermparent)",
   "license": "MIT",
   "dependencies": {
@@ -10,6 +11,12 @@
     "@reach/router": "^1.3.4",
     "@reach/skip-nav": "^0.17.0",
     "@svgr/webpack": "^6.2.1",
+    "@types/github-slugger": "^1.3.0",
+    "@types/isomorphic-fetch": "^0.0.36",
+    "@types/promise-polyfill": "^6.0.4",
+    "@types/react-collapse": "^5.0.1",
+    "@types/react-helmet": "^6.1.5",
+    "@types/unist": "^2.0.6",
     "autoprefixer": "^10.4.4",
     "classnames": "^2.3.1",
     "ease-component": "^1.0.0",
@@ -70,12 +77,6 @@
     "unist-util-visit": "^4.1.0"
   },
   "devDependencies": {
-    "@types/github-slugger": "^1.3.0",
-    "@types/isomorphic-fetch": "^0.0.36",
-    "@types/promise-polyfill": "^6.0.4",
-    "@types/react-collapse": "^5.0.1",
-    "@types/react-helmet": "^6.1.5",
-    "@types/unist": "^2.0.6",
     "eslint": "^8.12.0",
     "typescript": "^4.6.3"
   },

--- a/packages/gatsby-theme-iterative/src/typings.d.ts
+++ b/packages/gatsby-theme-iterative/src/typings.d.ts
@@ -19,6 +19,11 @@ declare module '*.svg' {
   export default filePath
 }
 
+declare module '*.mp4' {
+  const src: string
+  export default src
+}
+
 declare module 'scroll' {
   type ScrollTo = (
     node: Element,

--- a/packages/gatsby-theme-iterative/tsconfig.json
+++ b/packages/gatsby-theme-iterative/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
+    "jsx": "react",
+    "lib": ["dom", "es2015", "es2017", "es2021"],
+    "module": "commonjs",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "target": "es5"
+  },
+  "include": ["./src/**/*", "./*.js"]
+}


### PR DESCRIPTION
This PR makes the types we use across all sites exportable from this package. This is something I overlooked in #10 insofar as making mlem.ai's type checking pass, but with this (and some config on that end) it finally does.