### PR TITLE
Update dvc-commands.js

### DIFF
--- a/packages/gatsby-theme-iterative/config/prismjs/dvc-commands.js
+++ b/packages/gatsby-theme-iterative/config/prismjs/dvc-commands.js
@@ -55,6 +55,7 @@ module.exports = [
   'exp diff',
   'exp branch',
   'exp apply',
+  'exp init',
   'exp',
   'experiments',
   'doctor',


### PR DESCRIPTION
Add missing `exp init`.

Closes https://github.com/iterative/gatsby-theme-iterative/issues/50