### PR TITLE
Added a patch for image blur issue

### DIFF
--- a/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/index.tsx
+++ b/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/index.tsx
@@ -25,6 +25,7 @@ import { ReactComponent as LinkIcon } from '../../../images/linkIcon.svg'
 import { useLocation } from '@reach/router'
 
 import Slugger from '../../../utils/front/Slugger'
+import patchHtmlAst from '../../../utils/front/patchHtmlAst'
 
 type RemarkNode = { props: { children: RemarkNode[] } } | string
 
@@ -296,9 +297,10 @@ const Markdown: React.FC<IMarkdownProps> = ({
   githubLink
 }) => {
   const slugger = new Slugger()
+  const patchedAst = patchHtmlAst(htmlAst)
   return (
     <Main prev={prev} next={next} tutorials={tutorials} githubLink={githubLink}>
-      <TogglesProvider>{renderAst(slugger)(htmlAst)}</TogglesProvider>
+      <TogglesProvider>{renderAst(slugger)(patchedAst)}</TogglesProvider>
     </Main>
   )
 }

--- a/packages/gatsby-theme-iterative/src/utils/front/patchHtmlAst.ts
+++ b/packages/gatsby-theme-iterative/src/utils/front/patchHtmlAst.ts
@@ -1,0 +1,11 @@
+// Strange issue with srcSet value are without comma
+const patchHtmlAst = (ast: any) => {
+  if (ast.properties?.srcSet && Array.isArray(ast.properties.srcSet)) {
+    ast.properties.srcSet = ast.properties.srcSet.join(', ')
+  }
+  if (ast.children) {
+    ast.children = ast.children.map(patchHtmlAst)
+  }
+  return ast
+}
+export default patchHtmlAst


### PR DESCRIPTION
It turned out that the image `srcset` was missing commas. Hence, only the fallback image was used and the responsive image was not working. From my inspection, the images are passing fine from the plugins so I suspect the issue lies in either `gatsby-transformer-remark`  or `react-rehype` not being able to convert the srcSet. 
For now, it's handled by applying the patch.

Fixes #46 