### PR TITLE
Fix issues with trailing slashes on example

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -33,7 +33,7 @@ http {
 		server_name _;
 		keepalive_timeout 5;
 		client_max_body_size <%= ENV['NGINX_CLIENT_MAX_BODY_SIZE'] || 1 %>M;
-		rewrite ^([^.]*[^/])$ $1/ permanent;
+		try_files $uri/index.html $uri $uri/ @notfound;
 
 		root /app/packages/example/public;
 	}


### PR DESCRIPTION
This PR adds some config to the NGINX server that powers the example site, allowing for non-trailing slash to work properly. Before, you couldn't refresh a docs page.