### PR TITLE
Fix CLI highlighting for MLEM

### DIFF
--- a/packages/gatsby-theme-iterative/config/prismjs/mlem-commands.js
+++ b/packages/gatsby-theme-iterative/config/prismjs/mlem-commands.js
@@ -14,6 +14,6 @@ module.exports = [
   'clone',
   'import',
   'build',
-  'apply',
-  'apply-remote'
+  'apply-remote',
+  'apply'
 ]


### PR DESCRIPTION
close https://github.com/iterative/mlem.ai/issues/162

This should fix everything except for `mlem apply-remote` https://mlem.ai/doc/command-reference/apply-remote

`apply-remote` is already on the list in the file I edited, but for some reason it doesn't work (need to escape `-` maybe?)