### PR TITLE
Add update commands GHA

### DIFF
--- a/.github/workflows/update-commands.yml
+++ b/.github/workflows/update-commands.yml
@@ -1,9 +1,7 @@
 name: Update tool commands list for Prismjs
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 10 * * 1-5'
-  push:
 
 jobs:
   fetch-commands:


### PR DESCRIPTION
We maintain a list of commands for our tools at https://github.com/iterative/gatsby-theme-iterative/tree/main/packages/gatsby-theme-iterative/config/prismjs. 

Based on [comment](https://github.com/iterative/dvc.org/pull/3996#issuecomment-1259084189):
> I did write a [rough script](https://github.com/iterative/gatsby-theme-iterative/pull/18/files#diff-6335516df4ca9ea338a7966639c72d56013240d6b92affc717f53e4e1d6ff338) to update the commands a while back expecting this same situation. Now, we can bump up to higher priority and I think we can update this into GHA to create PR with CML.

I used CML to create PR if any commands are updated on the main repo's `sidebar.json`. 

Tested and it seems to be working as expected: https://github.com/iterative/gatsby-theme-iterative/pull/98
