### PR TITLE
Fix plausible script tags and make them configurable

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -16,7 +16,7 @@ module.exports = {
       resolve: themePackageName,
       options: {
         simpleLinkerTerms: require('./content/linked-terms'),
-        plausibleSrc: false
+        plausibleSrc: null
       }
     },
     {

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -9,7 +9,8 @@ module.exports = {
     title: 'Example website',
     description: 'Example website description',
     keywords: ['docs', 'test'],
-    siteUrl: 'http://localhost:8000'
+    siteUrl: 'http://localhost:8000',
+    plausibleDomain: ''
   },
   plugins: [
     {

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -9,14 +9,14 @@ module.exports = {
     title: 'Example website',
     description: 'Example website description',
     keywords: ['docs', 'test'],
-    siteUrl: 'http://localhost:8000',
-    plausibleDomain: ''
+    siteUrl: 'http://gatsby-theme-iterative-example.herokuapp.com'
   },
   plugins: [
     {
       resolve: themePackageName,
       options: {
         simpleLinkerTerms: require('./content/linked-terms')
+        //disablePlausible: true
       }
     },
     {

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -15,8 +15,8 @@ module.exports = {
     {
       resolve: themePackageName,
       options: {
-        simpleLinkerTerms: require('./content/linked-terms')
-        //disablePlausible: true
+        simpleLinkerTerms: require('./content/linked-terms'),
+        disablePlausible: true
       }
     },
     {

--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -16,7 +16,7 @@ module.exports = {
       resolve: themePackageName,
       options: {
         simpleLinkerTerms: require('./content/linked-terms'),
-        disablePlausible: true
+        plausibleSrc: false
       }
     },
     {

--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -171,10 +171,6 @@ module.exports = ({
     }
   ],
   siteMetadata: {
-    author: '',
-    siteUrl: '',
-    titleTemplate: '',
-    plausibleSrc: 'https://plausible.io/js/plausible.outbound-links.js',
-    plausibleDomain: ''
+    plausibleSrc: 'https://plausible.io/js/plausible.outbound-links.js'
   }
 })

--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -171,8 +171,10 @@ module.exports = ({
     }
   ],
   siteMetadata: {
-    author: 'Iterative',
-    siteUrl: 'https://cml.dev',
-    titleTemplate: ''
+    author: '',
+    siteUrl: '',
+    titleTemplate: '',
+    plausibleSrc: 'https://plausible.io/js/plausible.outbound-links.js',
+    plausibleDomain: ''
   }
 })

--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -171,6 +171,8 @@ module.exports = ({
     }
   ],
   siteMetadata: {
+    author: 'Iterative',
+    titleTemplate: '',
     plausibleSrc: '/pl/js/plausible.outbound-links.js',
     plausibleAPI: '/pl/api/event'
   }

--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -33,7 +33,9 @@ const imageMaxWidth = 700
 
 module.exports = ({
   simpleLinkerTerms,
-  disablePlausible,
+  plausibleSrc = '/pl/js/plausible.outbound-links.js',
+  plausibleAPI = '/pl/api/event',
+  plausibleDomain,
   cssBase = defaultCssBase,
   customMediaConfig = { importFrom: [mediaConfig] },
   customPropertiesConfig = {
@@ -174,9 +176,8 @@ module.exports = ({
   siteMetadata: {
     author: 'Iterative',
     titleTemplate: '',
-    plausibleSrc: disablePlausible
-      ? null
-      : '/pl/js/plausible.outbound-links.js',
-    plausibleAPI: '/pl/api/event'
+    plausibleSrc,
+    plausibleAPI,
+    plausibleDomain
   }
 })

--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -33,6 +33,7 @@ const imageMaxWidth = 700
 
 module.exports = ({
   simpleLinkerTerms,
+  disablePlausible,
   cssBase = defaultCssBase,
   customMediaConfig = { importFrom: [mediaConfig] },
   customPropertiesConfig = {
@@ -173,7 +174,9 @@ module.exports = ({
   siteMetadata: {
     author: 'Iterative',
     titleTemplate: '',
-    plausibleSrc: '/pl/js/plausible.outbound-links.js',
+    plausibleSrc: disablePlausible
+      ? null
+      : '/pl/js/plausible.outbound-links.js',
     plausibleAPI: '/pl/api/event'
   }
 })

--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -171,6 +171,7 @@ module.exports = ({
     }
   ],
   siteMetadata: {
-    plausibleSrc: 'https://plausible.io/js/plausible.outbound-links.js'
+    plausibleSrc: '/pl/js/plausible.outbound-links.js',
+    plausibleAPI: '/pl/api/event'
   }
 })

--- a/packages/gatsby-theme-iterative/gatsby-node.js
+++ b/packages/gatsby-theme-iterative/gatsby-node.js
@@ -57,6 +57,16 @@ exports.createSchemaCustomization = async api => {
         name: 'String!',
         match: '[String]'
       }
+    }),
+    buildObjectType({
+      name: 'SiteSiteMetadata',
+      fields: {
+        author: 'String',
+        siteUrl: 'String',
+        titleTemplate: 'String',
+        plausibleSrc: 'String',
+        plausibleDomain: 'String'
+      }
     })
   ])
 }

--- a/packages/gatsby-theme-iterative/gatsby-node.js
+++ b/packages/gatsby-theme-iterative/gatsby-node.js
@@ -27,9 +27,9 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     customPropertiesConfig: Joi.object(),
     colorModConfig: Joi.object(),
     postCssPlugins: Joi.array(),
-    plausibleSrc: Joi.string(),
-    plausibleAPI: Joi.string(),
-    plausibleDomain: Joi.string()
+    plausibleSrc: [Joi.string().optional(), Joi.allow(null)],
+    plausibleAPI: [Joi.string().optional(), Joi.allow(null)],
+    plausibleDomain: [Joi.string().optional(), Joi.allow(null)]
   })
 }
 
@@ -68,7 +68,8 @@ exports.createSchemaCustomization = async api => {
         siteUrl: 'String',
         titleTemplate: 'String',
         plausibleSrc: 'String',
-        plausibleDomain: 'String'
+        plausibleDomain: 'String',
+        plausibleAPI: 'String'
       }
     })
   ])

--- a/packages/gatsby-theme-iterative/gatsby-node.js
+++ b/packages/gatsby-theme-iterative/gatsby-node.js
@@ -27,7 +27,9 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     customPropertiesConfig: Joi.object(),
     colorModConfig: Joi.object(),
     postCssPlugins: Joi.array(),
-    disablePlausible: Joi.boolean().default(false)
+    plausibleSrc: Joi.string(),
+    plausibleAPI: Joi.string(),
+    plausibleDomain: Joi.string()
   })
 }
 

--- a/packages/gatsby-theme-iterative/gatsby-node.js
+++ b/packages/gatsby-theme-iterative/gatsby-node.js
@@ -26,7 +26,8 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     customMediaConfig: Joi.object(),
     customPropertiesConfig: Joi.object(),
     colorModConfig: Joi.object(),
-    postCssPlugins: Joi.array()
+    postCssPlugins: Joi.array(),
+    disablePlausible: Joi.boolean().default(false)
   })
 }
 

--- a/packages/gatsby-theme-iterative/gatsby-ssr.js
+++ b/packages/gatsby-theme-iterative/gatsby-ssr.js
@@ -1,5 +1,22 @@
 /* eslint-env node */
+const React = require('react')
 
 const PageWrapper = require('./src/components/PageWrapper').default
 
 exports.wrapPageElement = PageWrapper
+
+const onRenderBody = ({ setHeadComponents }, { disablePlausible }) => {
+  if (disablePlausible) {
+    return setHeadComponents([
+      <script
+        key="plausible-custom-events"
+        dangerouslySetInnerHTML={{
+          __html:
+            'window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }'
+        }}
+      />
+    ])
+  }
+}
+
+exports.onRenderBody = onRenderBody

--- a/packages/gatsby-theme-iterative/gatsby-ssr.js
+++ b/packages/gatsby-theme-iterative/gatsby-ssr.js
@@ -6,7 +6,7 @@ const PageWrapper = require('./src/components/PageWrapper').default
 exports.wrapPageElement = PageWrapper
 
 const onRenderBody = ({ setHeadComponents }, { disablePlausible }) => {
-  if (disablePlausible) {
+  if (!disablePlausible) {
     return setHeadComponents([
       <script
         key="plausible-custom-events"

--- a/packages/gatsby-theme-iterative/gatsby-ssr.js
+++ b/packages/gatsby-theme-iterative/gatsby-ssr.js
@@ -5,8 +5,8 @@ const PageWrapper = require('./src/components/PageWrapper').default
 
 exports.wrapPageElement = PageWrapper
 
-const onRenderBody = ({ setHeadComponents }, { disablePlausible }) => {
-  if (!disablePlausible) {
+const onRenderBody = ({ setHeadComponents }, { plausibleSrc }) => {
+  if (plausibleSrc) {
     return setHeadComponents([
       <script
         key="plausible-custom-events"

--- a/packages/gatsby-theme-iterative/package.json
+++ b/packages/gatsby-theme-iterative/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvcorg/gatsby-theme-iterative",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "",
   "main": "index.js",
   "types": "src/typings.d.ts",

--- a/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
+++ b/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Script } from 'gatsby'
 import Helmet from 'react-helmet'
 
 import { MetaProps } from '../../SEO'
@@ -17,11 +16,15 @@ const metaImage = {
 
 const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
   const siteMeta = getSiteMeta()
-  const siteUrl = siteMeta.siteUrl
-  const metaTitle = siteMeta.title
-  const metaTitleTemplate = siteMeta.titleTemplate
-  const metaDescription = siteMeta.description
-  const metaKeywords = siteMeta.keywords
+  const {
+    siteUrl,
+    titleTemplate,
+    title: metaTitle,
+    description: metaDescription,
+    keywords: metaKeywords,
+    plausibleDomain,
+    plausibleSrc
+  } = siteMeta
   const fullUrl = siteUrl + pathname
 
   const meta: MetaProps[] = [
@@ -104,32 +107,29 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
   ]
 
   return (
-    <>
-      <Helmet
-        htmlAttributes={{
-          lang: 'en'
-        }}
-        defaultTitle={metaTitle}
-        titleTemplate={metaTitleTemplate || `%s | ${metaTitle}`}
-        meta={meta}
-        link={[
-          {
-            rel: 'mask-icon',
-            href: '/safari-pinned-tab.svg',
-            color: '#13adc7'
-          },
-          {
-            rel: 'canonical',
-            href: fullUrl
-          }
-        ]}
-      />
-      <Script
-        defer
-        data-domain="dvc.org"
-        src="https://plausible.io/js/plausible.outbound-links.js"
-      />
-    </>
+    <Helmet
+      htmlAttributes={{
+        lang: 'en'
+      }}
+      defaultTitle={metaTitle}
+      titleTemplate={titleTemplate || `%s | ${metaTitle}`}
+      meta={meta}
+      link={[
+        {
+          rel: 'mask-icon',
+          href: '/safari-pinned-tab.svg',
+          color: '#13adc7'
+        },
+        {
+          rel: 'canonical',
+          href: fullUrl
+        }
+      ]}
+    >
+      {plausibleDomain ? (
+        <script defer data-domain={plausibleDomain} src={plausibleSrc} />
+      ) : null}
+    </Helmet>
   )
 }
 

--- a/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
+++ b/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
@@ -28,9 +28,6 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
   } = siteMeta
   const fullUrl = siteUrl + pathname
 
-  const plausibleDomainOrDefault =
-    plausibleDomain === null ? new URL(siteUrl).hostname : plausibleDomain
-
   const meta: MetaProps[] = [
     {
       name: 'description',
@@ -130,12 +127,12 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
         }
       ]}
     >
-      {plausibleDomainOrDefault ? (
+      {plausibleSrc ? (
         <script
           defer
-          data-domain={plausibleDomainOrDefault || undefined}
+          data-domain={plausibleDomain || new URL(siteUrl).hostname}
           data-api={plausibleAPI || undefined}
-          src={plausibleSrc || undefined}
+          src={plausibleSrc}
         />
       ) : null}
     </Helmet>

--- a/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
+++ b/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
@@ -23,7 +23,8 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
     description: metaDescription,
     keywords: metaKeywords,
     plausibleDomain,
-    plausibleSrc
+    plausibleSrc,
+    plausibleAPI
   } = siteMeta
   const fullUrl = siteUrl + pathname
 
@@ -132,8 +133,9 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
       {plausibleDomainOrDefault ? (
         <script
           defer
-          data-domain={plausibleDomainOrDefault}
-          src={plausibleSrc}
+          data-domain={plausibleDomainOrDefault || undefined}
+          data-api={plausibleAPI || undefined}
+          src={plausibleSrc || undefined}
         />
       ) : null}
     </Helmet>

--- a/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
+++ b/packages/gatsby-theme-iterative/src/components/Page/DefaultSEO/index.tsx
@@ -27,6 +27,9 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
   } = siteMeta
   const fullUrl = siteUrl + pathname
 
+  const plausibleDomainOrDefault =
+    plausibleDomain === null ? new URL(siteUrl).hostname : plausibleDomain
+
   const meta: MetaProps[] = [
     {
       name: 'description',
@@ -126,8 +129,12 @@ const DefaultSEO: React.FC<IDefaultSEOProps> = ({ pathname }) => {
         }
       ]}
     >
-      {plausibleDomain ? (
-        <script defer data-domain={plausibleDomain} src={plausibleSrc} />
+      {plausibleDomainOrDefault ? (
+        <script
+          defer
+          data-domain={plausibleDomainOrDefault}
+          src={plausibleSrc}
+        />
       ) : null}
     </Helmet>
   )

--- a/packages/gatsby-theme-iterative/src/queries/siteMeta.ts
+++ b/packages/gatsby-theme-iterative/src/queries/siteMeta.ts
@@ -6,8 +6,9 @@ interface ISiteMeta {
   keywords: string
   siteUrl: string
   titleTemplate: string
-  plausibleDomain: string
-  plausibleSrc: string
+  plausibleDomain: string | null
+  plausibleSrc: string | null
+  plausibleAPI: string | null
 }
 
 export default function siteMeta(): ISiteMeta {
@@ -25,6 +26,7 @@ export default function siteMeta(): ISiteMeta {
             titleTemplate
             plausibleDomain
             plausibleSrc
+            plausibleAPI
           }
         }
       }

--- a/packages/gatsby-theme-iterative/src/queries/siteMeta.ts
+++ b/packages/gatsby-theme-iterative/src/queries/siteMeta.ts
@@ -6,6 +6,8 @@ interface ISiteMeta {
   keywords: string
   siteUrl: string
   titleTemplate: string
+  plausibleDomain: string
+  plausibleSrc: string
 }
 
 export default function siteMeta(): ISiteMeta {
@@ -21,6 +23,8 @@ export default function siteMeta(): ISiteMeta {
             keywords
             siteUrl
             titleTemplate
+            plausibleDomain
+            plausibleSrc
           }
         }
       }


### PR DESCRIPTION
Before, the plausible scripts added by this theme were:

1. broken in some metrics like bounce rate because the `Script` tag put them at the bottom.
2. all hard-coded to point to `dvc.org` :grimacing:

This PR changes that by turning the plausible domain and script source into options configurable via Gatsby's `siteMetadata` feature under the keys `plausibleDomain` and `plausibleSrc`. 

- `plausibleDomain` determines the domain the site reports to Plausible as, and if it isn't specified the domain is inferred from `siteMetadata.siteUrl`
- `plausibleSrc` allows us to specify the `src` tag of the plausible script, defaulting to our `websites-server`-proxied version of the `outbound-links` script. Cases where this would be overridden would include:
  - using the non-`outbound-links` version of the script
  - using a proxy at a path different from `websites-server`
  - using a non-proxy version

  This will change once we shift toward making this more useful to the public

:warning: I've rebased this branch onto a new `maintenance` branch that reverts #33, so we can make a bugfix release on the 0.1 line and make this fix get in ASAP

Here's an example of the resulting script tag
![image](https://user-images.githubusercontent.com/9111807/201228591-05ae7b36-1633-4e10-a2ce-14ee8c6d0dd2.png)
