### PR TITLE
Add subtler tab styling

### DIFF
--- a/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/ToggleProvider/styles.module.css
+++ b/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/ToggleProvider/styles.module.css
@@ -42,9 +42,7 @@
 
 .tab {
   @apply p-2 m-0;
-  border-left-color: lightblue;
-  border-left-width: thick;
-  border-left-style: groove;
+  border-left: thick groove #caf3fa;
   height: 0;
   opacity: 0;
   position: absolute;

--- a/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/ToggleProvider/styles.module.css
+++ b/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/ToggleProvider/styles.module.css
@@ -41,9 +41,10 @@
 }
 
 .tab {
-  margin: 0;
-  padding: 10px 10px 10px 20px;
-  background-color: rgb(27 31 35 / 5%);
+  @apply p-2 m-0;
+  border-left-color: lightblue;
+  border-left-width: thick;
+  border-left-style: groove;
   height: 0;
   opacity: 0;
   position: absolute;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9111807/204959444-4de46c5d-5fae-413b-8198-1d87ae61b301.png)

Starting off with @casperdcl's border suggestion along with a smaller padding, particularly on the left side. 

fixes #138