### PR TITLE
Fix right sidebar being too spaced out

### DIFF
--- a/packages/gatsby-theme-iterative/src/components/Documentation/RightPanel/styles.module.css
+++ b/packages/gatsby-theme-iterative/src/components/Documentation/RightPanel/styles.module.css
@@ -13,7 +13,7 @@
 }
 
 .contentBlock {
-  @apply basis-36 grow min-h-[6rem];
+  @apply basis-auto min-h-[6rem];
 
   overflow-y: scroll;
   margin-bottom: 17px;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/9111807/204993916-a3185410-f814-4d31-b385-0c6cd69af10a.png)

after:
![image](https://user-images.githubusercontent.com/9111807/204993258-021a641a-e3dd-4b67-a60f-054819afd3b1.png)