### PR TITLE
Configure Sentry through plugin options

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -16,7 +16,8 @@ module.exports = {
       resolve: themePackageName,
       options: {
         simpleLinkerTerms: require('./content/linked-terms'),
-        plausibleSrc: null
+        plausibleSrc: null,
+        sentry: false
       }
     },
     {
@@ -25,7 +26,6 @@ module.exports = {
         name: 'images',
         path: path.join(__dirname, 'static', 'img')
       }
-    },
-    '@sentry/gatsby'
+    }
   ]
 }

--- a/packages/example/sentry.config.js
+++ b/packages/example/sentry.config.js
@@ -1,4 +1,0 @@
-import * as Sentry from '@sentry/gatsby'
-import sentryConfig from '@dvcorg/gatsby-theme-iterative/sentry-config'
-
-Sentry.init(sentryConfig)

--- a/packages/gatsby-theme-iterative/README.md
+++ b/packages/gatsby-theme-iterative/README.md
@@ -117,40 +117,17 @@ others in the future.
   This is the prefix that the docs pages will render to, including the index
   page at the exact path.
 
+- sentry: boolean
+
+  Default: true
+
+  If true, this theme will instantiate `@sentry/gatsby` with a default
+  configuration. This configuration can be imported from `sentry-config.js` and
+  overridden by creating a
+  [Sentry configuration file](https://docs.sentry.io/platforms/javascript/guides/gatsby/#sentry-configuration-file)
+  in your project's root.
+
 ### Examples
 
-See this example from
-[the example website's `gatsby-config.js`](https://github.com/iterative/gatsby-theme-iterative/blob/main/packages/example/gatsby-config.js).
-
-```js
-const path = require('path')
-const {
-  name: themePackageName
-} = require('../gatsby-theme-iterative/package.json')
-
-module.exports = {
-  trailingSlash: 'never',
-  siteMetadata: {
-    title: 'Example website',
-    description: 'Example website description',
-    keywords: ['docs', 'test'],
-    siteUrl: 'http://localhost:8000'
-  },
-  plugins: [
-    {
-      resolve: themePackageName,
-      options: {
-        simpleLinkerTerms: require('./content/linked-terms')
-      }
-    },
-    {
-      resolve: 'gatsby-source-filesystem',
-      options: {
-        name: 'images',
-        path: path.join(__dirname, 'static', 'img')
-      }
-    },
-    '@sentry/gatsby'
-  ]
-}
-```
+Check out the example project in this project's monorepo, particularly
+[`gatsby-config.js`](https://github.com/iterative/gatsby-theme-iterative/blob/main/packages/example/gatsby-config.js).

--- a/packages/gatsby-theme-iterative/config-defaults.js
+++ b/packages/gatsby-theme-iterative/config-defaults.js
@@ -5,5 +5,6 @@ module.exports = {
   docsInstanceName: 'iterative-docs',
   glossaryPath: path.resolve('content', 'docs', 'user-guide', 'basic-concepts'),
   glossaryInstanceName: 'iterative-glossary',
-  argsLinkerPath: ['command-reference', `ref`, 'cli-reference']
+  argsLinkerPath: ['command-reference', `ref`, 'cli-reference'],
+  sentry: true
 }

--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -17,6 +17,7 @@ require('./config/prismjs/dvctable')
 const imageMaxWidth = 700
 
 const defaults = require('./config-defaults')
+const sentryConfig = require('./sentry-config')
 
 module.exports = ({
   simpleLinkerTerms,
@@ -32,7 +33,8 @@ module.exports = ({
   docsPath = defaults.docsPath,
   glossaryInstanceName = defaults.glossaryInstanceName,
   glossaryPath = defaults.glossaryPath,
-  argsLinkerPath = defaults.argsLinkerPath
+  argsLinkerPath = defaults.argsLinkerPath,
+  sentry = defaults.sentry
 }) => ({
   plugins: [
     {
@@ -153,6 +155,10 @@ module.exports = ({
           placeholder: 'blurred'
         }
       }
+    },
+    sentry && {
+      resolve: '@sentry/gatsby',
+      options: sentryConfig
     }
   ].filter(Boolean),
   siteMetadata: {

--- a/packages/gatsby-theme-iterative/gatsby-node.js
+++ b/packages/gatsby-theme-iterative/gatsby-node.js
@@ -37,7 +37,8 @@ exports.pluginOptionsSchema = ({ Joi }) => {
       .default(defaults.argsLinkerPath),
     plausibleSrc: [Joi.string().optional(), Joi.allow(null)],
     plausibleAPI: [Joi.string().optional(), Joi.allow(null)],
-    plausibleDomain: [Joi.string().optional(), Joi.allow(null)]
+    plausibleDomain: [Joi.string().optional(), Joi.allow(null)],
+    sentry: Joi.boolean().default(defaults.sentry)
   })
 }
 

--- a/packages/gatsby-theme-iterative/sentry-config.js
+++ b/packages/gatsby-theme-iterative/sentry-config.js
@@ -2,7 +2,7 @@
  * Much of this is lifted from Sentry's docs
  * see https://docs.sentry.io/platforms/javascript/guides/gatsby/configuration/filtering/#decluttering-sentry
  */
-export default {
+module.exports = {
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
   release: process.env.SOURCE_VERSION,


### PR DESCRIPTION
The dsn wasn't passing to the client with the way we were configuring Sentry. While Sentry docs recommend using `sentry.config.js`, it's actually preferable to use plugin options as a library because:
- We can with the config we current have because we don't use non-serializable values
- Consumers can optionally override by simply adding a `sentry.config.js`, which can even import our options set and extend it!