### PR TITLE
Add plugin to skip command linker

### DIFF
--- a/packages/gatsby-theme-iterative/gatsby-config.js
+++ b/packages/gatsby-theme-iterative/gatsby-config.js
@@ -135,7 +135,8 @@ module.exports = ({
           },
           'gatsby-remark-responsive-iframe',
           require.resolve('./plugins/resize-image-plugin'),
-          require.resolve('./plugins/external-link-plugin')
+          require.resolve('./plugins/external-link-plugin'),
+          require.resolve('./plugins/null-link-plugin')
         ]
       }
     },

--- a/packages/gatsby-theme-iterative/plugins/null-link-plugin/index.js
+++ b/packages/gatsby-theme-iterative/plugins/null-link-plugin/index.js
@@ -1,0 +1,9 @@
+module.exports = async ({ markdownAST }) => {
+  const { visit } = await import('unist-util-visit')
+  visit(markdownAST, 'link', node => {
+    if (!node.url && node?.children?.[0]?.type === 'inlineCode') {
+      node.type = 'inlineCode'
+      node.value = node.children[0].value
+    }
+  })
+}

--- a/packages/gatsby-theme-iterative/plugins/null-link-plugin/package.json
+++ b/packages/gatsby-theme-iterative/plugins/null-link-plugin/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "null-link-plugin",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "yathomasi",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
By default, our command line linkers always link any inline code based on `dvc`, `cml`, ... our tools. 

If we want to customize them we can always wrap the inline code with a link eg:
```
[`dvc ...`](link)
```

This PR adds a plugin to allow us to have no link at all. For that, we can pass no value. eg:
```
[`dvc ...`]()
```

closes https://github.com/iterative/cml.dev/issues/424