### PR TITLE
Fix right-edge padding on code blocks

### DIFF
--- a/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/Main/theme.module.css
+++ b/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/Main/theme.module.css
@@ -23,8 +23,12 @@
       background-color: var(--bg-dark);
       border-radius: 0.3em;
       margin: 0.5em 0;
-      padding: 1em;
       overflow: auto;
+
+      & > pre {
+        display: inline-block;
+        padding: 1em;
+      }
     }
 
     /**

--- a/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/Main/theme.module.css
+++ b/packages/gatsby-theme-iterative/src/components/Documentation/Markdown/Main/theme.module.css
@@ -24,11 +24,6 @@
       border-radius: 0.3em;
       margin: 0.5em 0;
       overflow: auto;
-
-      & > pre {
-        display: inline-block;
-        padding: 1em;
-      }
     }
 
     /**
@@ -39,9 +34,10 @@
   * 3. Adjust the position of the line numbers
   */
     .gatsby-highlight pre[class*="language-"] {
+      display: inline-block;
       background-color: transparent;
       margin: 0;
-      padding: 0;
+      padding: 1em;
       overflow: initial;
       float: left; /* 1 */
       min-width: 100%; /* 2 */


### PR DESCRIPTION
Fixes #169 

Before:

![image](https://user-images.githubusercontent.com/9111807/214995490-d8f93ed9-fec6-44f3-8348-ce946674aebd.png)

After:

![image](https://user-images.githubusercontent.com/9111807/214995718-eaf3d226-2198-4f69-8d94-c40607b51223.png)
