### PR TITLE
update dvclive api url

### DIFF
--- a/packages/gatsby-theme-iterative/plugins/gatsby-remark-dvc-linker/index.test.js
+++ b/packages/gatsby-theme-iterative/plugins/gatsby-remark-dvc-linker/index.test.js
@@ -27,7 +27,7 @@ describe('gatsby-remark-dvc-linker', async () => {
 
   live = {
     inlineCode: '`Live.log()`',
-    url: '[`Live.log()`](/doc/dvclive/api-reference/live/log)'
+    url: '[`Live.log()`](/doc/dvclive/live/log)'
   }
 
   it('composes apiLinker and commandLinker', () => {

--- a/packages/gatsby-theme-iterative/plugins/gatsby-remark-dvc-linker/liveLinker.js
+++ b/packages/gatsby-theme-iterative/plugins/gatsby-remark-dvc-linker/liveLinker.js
@@ -5,7 +5,7 @@ const { getItemByPath } = require('../../src/utils/shared/sidebar')
 
 const LIVE_API_REGEXP = /Live.([a-z-._]*\(\)$)?/
 const METHOD_REGEXP = /^[a-z-._]*\(\)$/
-const API_ROOT = '/doc/dvclive/api-reference/live/'
+const API_ROOT = '/doc/dvclive/live/'
 
 module.exports = astNode => {
   const node = astNode[0]


### PR DESCRIPTION
The URL for the DVCLive API reference docs was updated and broke the linking. See https://github.com/iterative/dvc.org/pull/4422.