### PR TITLE
fix(sidebar): set next/prev properly on deep nested tree

### DIFF
--- a/packages/gatsby-theme-iterative/src/utils/shared/sidebar.js
+++ b/packages/gatsby-theme-iterative/src/utils/shared/sidebar.js
@@ -156,6 +156,8 @@ function normalizeSidebar({
       prevRef.next = normalizedItem.path
     }
 
+    prevRef = normalizedItem
+
     if (rawItem.children) {
       normalizedItem.children = normalizeSidebar({
         data: rawItem.children,
@@ -164,9 +166,9 @@ function normalizeSidebar({
         startingPrevRef: normalizedItem
       })
 
-      prevRef = normalizedItem.children[normalizedItem.children.length - 1]
-    } else {
-      prevRef = normalizedItem
+      while (prevRef.children) {
+        prevRef = prevRef.children[prevRef.children.length - 1]
+      }
     }
 
     currentResult.push(normalizedItem)

--- a/packages/gatsby-theme-iterative/src/utils/shared/sidebar.test.js
+++ b/packages/gatsby-theme-iterative/src/utils/shared/sidebar.test.js
@@ -154,37 +154,77 @@ describe('normalizeSidebar', () => {
       expect(sidebarData).toEqual(result)
     })
 
-    it('Adds correct prev/next links in nested list', () => {
+    it('Adds correct prev/next links in nested lists', () => {
       const rawData = [
-        { slug: 'first-item', children: ['nested-item'] },
+        {
+          slug: 'first-item',
+          children: [
+            'nested-item-first',
+            {
+              slug: 'nested-item-second',
+              source: 'nested-item-second/index.md',
+              children: ['nested-nested-item']
+            }
+          ]
+        },
         'second-item'
       ]
+
       const result = [
         {
-          label: 'First Item',
           path: '/doc/first-item',
           source: '/docs/first-item.md',
+          label: 'First Item',
           tutorials: {},
           prev: undefined,
-          next: '/doc/first-item/nested-item',
+          next: '/doc/first-item/nested-item-first',
+          style: undefined,
+          icon: undefined,
           children: [
             {
-              label: 'Nested Item',
-              path: '/doc/first-item/nested-item',
-              source: '/docs/first-item/nested-item.md',
+              path: '/doc/first-item/nested-item-first',
+              source: '/docs/first-item/nested-item-first.md',
+              label: 'Nested Item First',
               tutorials: {},
               prev: '/doc/first-item',
-              next: '/doc/second-item'
+              next: '/doc/first-item/nested-item-second',
+              style: undefined,
+              icon: undefined
+            },
+            {
+              path: '/doc/first-item/nested-item-second',
+              source: '/docs/first-item/nested-item-second/index.md',
+              label: 'Nested Item Second',
+              tutorials: {},
+              prev: '/doc/first-item/nested-item-first',
+              next: '/doc/first-item/nested-item-second/nested-nested-item',
+              style: undefined,
+              icon: undefined,
+              children: [
+                {
+                  path: '/doc/first-item/nested-item-second/nested-nested-item',
+                  source:
+                    '/docs/first-item/nested-item-second/nested-nested-item.md',
+                  label: 'Nested Nested Item',
+                  tutorials: {},
+                  prev: '/doc/first-item/nested-item-second',
+                  next: '/doc/second-item',
+                  style: undefined,
+                  icon: undefined
+                }
+              ]
             }
           ]
         },
         {
-          label: 'Second Item',
           path: '/doc/second-item',
           source: '/docs/second-item.md',
+          label: 'Second Item',
           tutorials: {},
-          prev: '/doc/first-item/nested-item',
-          next: undefined
+          prev: '/doc/first-item/nested-item-second/nested-nested-item',
+          next: undefined,
+          style: undefined,
+          icon: undefined
         }
       ]
 


### PR DESCRIPTION
Fixes #200 

The issue was in not going deep in enough in children hierarchy to set the "previous" item pointer. It was setting it only to the next level of children:

```
- first item
  - nested item <--- it would always pick this as a previous while processing the `second item` below
     - nested nested item
        - - nested nested nested item <--- we should go down the tree to the bottom to find the deepest child
- second item
```