### PR TITLE
chore: add link to the enterprise cloud.dvc.ai site

### DIFF
--- a/packages/gatsby-theme-iterative/src/components/LayoutHeader/Nav/index.tsx
+++ b/packages/gatsby-theme-iterative/src/components/LayoutHeader/Nav/index.tsx
@@ -4,6 +4,8 @@ import cn from 'classnames'
 import PseudoButton from '../../PseudoButton'
 import SocialIcons from './SocialIcons'
 import LinkItems from './LinkItems'
+import Link from '../../Link'
+import { ReactComponent as ExternalLinkIcon } from '../../../images/external-link-icon.svg'
 
 import { logEvent } from '../../../utils/front/plausible'
 
@@ -21,6 +23,11 @@ const Nav: React.FC = () => (
     >
       Get Started
     </PseudoButton>
+    <div className="px-4">|</div>
+    <Link href="https://cloud.dvc.ai">
+      Get Enterprise{` `}
+      <ExternalLinkIcon className="ml-1 inline" />
+    </Link>
   </div>
 )
 


### PR DESCRIPTION
NOTE: This is untested, so don't merge this yet.

I need help to figure out how to locally test changes to the Gatsby theme (I ran `yarn link` but couldn't get `yarn develop` to run after doing so). The goal is to create a link in the header of dvc.org to cloud.dvc.ai that mirrors the link in the header of cloud.dev.ai to dvc.org. See https://github.com/iterative/cloud.dvc.ai/pull/7/files#diff-70dcc0a37baa905f8c07089263f326dd43c8d429759793983f03a5e14e4b9640R238-R246