### PR TITLE
fix(cli): add artifacts get to the highlighter

### DIFF
--- a/packages/gatsby-theme-iterative/config/prismjs/dvc-commands.js
+++ b/packages/gatsby-theme-iterative/config/prismjs/dvc-commands.js
@@ -1,5 +1,7 @@
 module.exports = [
   'add',
+  'artifacts get',
+  'artifacts',
   'cache dir',
   'cache',
   'check-ignore',


### PR DESCRIPTION
Adds `artifacts` commands to the syntax highlighter.